### PR TITLE
Moved bib item to citation section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,37 +23,11 @@
 
 ---
 
-```bibtex
-@inproceedings{delbrouck-etal-2022-vilmedic,
-    title = "{V}i{LM}edic: a framework for research at the intersection of vision and language in medical {AI}",
-    author = "Delbrouck, Jean-benoit  and
-      Saab, Khaled  and
-      Varma, Maya  and
-      Eyuboglu, Sabri  and
-      Chambon, Pierre  and
-      Dunnmon, Jared  and
-      Zambrano, Juan  and
-      Chaudhari, Akshay  and
-      Langlotz, Curtis",
-    booktitle = "Proceedings of the 60th Annual Meeting of the Association for Computational Linguistics: System Demonstrations",
-    month = may,
-    year = "2022",
-    address = "Dublin, Ireland",
-    publisher = "Association for Computational Linguistics",
-    url = "https://aclanthology.org/2022.acl-demo.3",
-    pages = "23--34",
-}
-```
-
-
 # Quickstart and documentation
 
 <p align="center">
 Rendez-vous at: <a href="https://vilmedic.app/installation/">https://vilmedic.app/installation/</a>
 </p>
-
-
-
 
 
 #### Implemented solutions
@@ -105,6 +79,28 @@ ViLMedic replicates solutions from the multimodal medical literature.
 ## Citation
 
 If you use ViLMedic in your work or use any models published in ViLMedic, please cite:
+
+```bibtex
+@inproceedings{delbrouck-etal-2022-vilmedic,
+    title = "{V}i{LM}edic: a framework for research at the intersection of vision and language in medical {AI}",
+    author = "Delbrouck, Jean-benoit  and
+      Saab, Khaled  and
+      Varma, Maya  and
+      Eyuboglu, Sabri  and
+      Chambon, Pierre  and
+      Dunnmon, Jared  and
+      Zambrano, Juan  and
+      Chaudhari, Akshay  and
+      Langlotz, Curtis",
+    booktitle = "Proceedings of the 60th Annual Meeting of the Association for Computational Linguistics: System Demonstrations",
+    month = may,
+    year = "2022",
+    address = "Dublin, Ireland",
+    publisher = "Association for Computational Linguistics",
+    url = "https://aclanthology.org/2022.acl-demo.3",
+    pages = "23--34",
+}
+```
 
 ## License
 ViLMedic is MIT-licensed. The license applies to the pre-trained models as well.


### PR DESCRIPTION
Looked like something might have gone wrong in a commit. The bib item had been placed at the top of the README, leaving the citation section fractured, expecting the bib item underneath.

I simply moved the bib item to the right place. Perhaps it was moved there for a reason, idk. Looked strange.